### PR TITLE
Bump GitHub Actions in dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'true'
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x' # SDK Version to use; x will use the latest version of the 3.1 channel
+        dotnet-version: '10.0.x'
     - name: Start containers
       run: docker compose -f "./docker-compose.yml" up -d --build           
     - name: Build


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-dotnet` v1 → v5
- Drop the stale inline comment that referenced the 3.1 SDK channel.

## Test plan
- [ ] CI runs successfully on this PR.