### PR TITLE
Bump NuGet package versions

### DIFF
--- a/Cleipnir.Tests.AspNet/Cleipnir.Tests.AspNet.csproj
+++ b/Cleipnir.Tests.AspNet/Cleipnir.Tests.AspNet.csproj
@@ -11,14 +11,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Cleipnir.Tests/Cleipnir.Tests.csproj
+++ b/Cleipnir.Tests/Cleipnir.Tests.csproj
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Cleipnir/Cleipnir.csproj
+++ b/Cleipnir/Cleipnir.csproj
@@ -24,7 +24,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -45,7 +45,7 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	</PropertyGroup>
 	<ItemGroup Label="SourceLink">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Cleipnir.ResilientFunctions\Core\Cleipnir.ResilientFunctions\Cleipnir.ResilientFunctions.csproj" />

--- a/Samples/Cleipnir.Sample.AspNet/Cleipnir.Sample.AspNet.csproj
+++ b/Samples/Cleipnir.Sample.AspNet/Cleipnir.Sample.AspNet.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Cleipnir.Sample.Presentation.AspNet/Cleipnir.Sample.Presentation.AspNet.csproj
+++ b/Samples/Cleipnir.Sample.Presentation.AspNet/Cleipnir.Sample.Presentation.AspNet.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Polly.Core" Version="8.6.6" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Cleipnir.Sample.Presentation/Cleipnir.Sample.Presentation.csproj
+++ b/Samples/Cleipnir.Sample.Presentation/Cleipnir.Sample.Presentation.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.15.1" />
+        <PackageReference Include="MailKit" Version="4.16.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>
 </Project>

--- a/ServiceBuses/Kafka/Cleipnir.Kafka.Tests/Cleipnir.Kafka.Tests.csproj
+++ b/ServiceBuses/Kafka/Cleipnir.Kafka.Tests/Cleipnir.Kafka.Tests.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" Version="2.13.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest" Version="4.1.0" />
+        <PackageReference Include="Confluent.Kafka" Version="2.14.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ServiceBuses/MassTransit/Cleipnir.MassTransit.Console/Cleipnir.MassTransit.Console.csproj
+++ b/ServiceBuses/MassTransit/Cleipnir.MassTransit.Console/Cleipnir.MassTransit.Console.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MassTransit" Version="9.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+      <PackageReference Include="MassTransit" Version="9.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ServiceBuses/MassTransit/Cleipnir.MassTransit.RabbitMq.Console/Cleipnir.MassTransit.RabbitMq.Console.csproj
+++ b/ServiceBuses/MassTransit/Cleipnir.MassTransit.RabbitMq.Console/Cleipnir.MassTransit.RabbitMq.Console.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MassTransit" Version="9.0.1" />
-      <PackageReference Include="MassTransit.RabbitMQ" Version="9.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+      <PackageReference Include="MassTransit" Version="9.1.0" />
+      <PackageReference Include="MassTransit.RabbitMQ" Version="9.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ServiceBuses/MassTransit/Cleipnir.MassTransit.Tests/Cleipnir.MassTransit.Tests.csproj
+++ b/ServiceBuses/MassTransit/Cleipnir.MassTransit.Tests/Cleipnir.MassTransit.Tests.csproj
@@ -10,17 +10,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="MassTransit" Version="9.0.1" />
-        <PackageReference Include="MassTransit.RabbitMQ" Version="9.0.1" />
+        <PackageReference Include="MassTransit" Version="9.1.0" />
+        <PackageReference Include="MassTransit.RabbitMQ" Version="9.1.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
     </ItemGroup>
 

--- a/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Console/Cleipnir.NServiceBus.Console.csproj
+++ b/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Console/Cleipnir.NServiceBus.Console.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-      <PackageReference Include="NServiceBus" Version="10.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+      <PackageReference Include="NServiceBus" Version="10.1.3" />
       <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0" />
     </ItemGroup>
 

--- a/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Tests/Cleipnir.NServiceBus.Tests.csproj
+++ b/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Tests/Cleipnir.NServiceBus.Tests.csproj
@@ -10,16 +10,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="NServiceBus" Version="10.1.0" />
+        <PackageReference Include="NServiceBus" Version="10.1.3" />
         <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0" />
     </ItemGroup>
 

--- a/ServiceBuses/Rebus/Cleipnir.Rebus.Console/Cleipnir.Rebus.Console.csproj
+++ b/ServiceBuses/Rebus/Cleipnir.Rebus.Console/Cleipnir.Rebus.Console.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Rebus" Version="8.9.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Rebus" Version="8.9.2" />
       <PackageReference Include="Rebus.ServiceProvider" Version="10.7.2" />
     </ItemGroup>
 

--- a/ServiceBuses/Rebus/Cleipnir.Rebus.Tests/Cleipnir.Rebus.Tests.csproj
+++ b/ServiceBuses/Rebus/Cleipnir.Rebus.Tests/Cleipnir.Rebus.Tests.csproj
@@ -10,15 +10,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
-        <PackageReference Include="Rebus" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+        <PackageReference Include="Rebus" Version="8.9.2" />
         <PackageReference Include="Rebus.ServiceProvider" Version="10.7.2" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
     </ItemGroup>

--- a/ServiceBuses/Wolverine/Cleipnir.Wolverine.Console/Cleipnir.Wolverine.Console.csproj
+++ b/ServiceBuses/Wolverine/Cleipnir.Wolverine.Console/Cleipnir.Wolverine.Console.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-      <PackageReference Include="WolverineFx" Version="5.19.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+      <PackageReference Include="WolverineFx" Version="5.32.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Stores/Cleipnir.MariaDB/Cleipnir.MariaDB.csproj
+++ b/Stores/Cleipnir.MariaDB/Cleipnir.MariaDB.csproj
@@ -46,7 +46,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
     <ItemGroup Label="SourceLink">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/Stores/Cleipnir.PostgresSql/Cleipnir.PostgresSql.csproj
+++ b/Stores/Cleipnir.PostgresSql/Cleipnir.PostgresSql.csproj
@@ -46,7 +46,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
     <ItemGroup Label="SourceLink">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="all" />
     </ItemGroup>
     
 </Project>

--- a/Stores/Cleipnir.SqlServer/Cleipnir.SqlServer.csproj
+++ b/Stores/Cleipnir.SqlServer/Cleipnir.SqlServer.csproj
@@ -46,7 +46,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
     <ItemGroup Label="SourceLink">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Updates 17 NuGet packages across 19 projects in the main repo (excluding the `Cleipnir.ResilientFunctions` submodule).
- Notable bumps: WolverineFx 5.19.1 → 5.32.1, coverlet.collector 8.0.0 → 10.0.0, MSTest 4.1.0 → 4.2.1, MassTransit 9.0.1 → 9.1.0, Microsoft.Extensions.* 10.0.5 → 10.0.7.
- `dotnet build` passes locally with 0 warnings, 0 errors.

## Test plan
- [ ] CI build succeeds
- [ ] Run unit tests across all test projects
- [ ] Smoke-test the WolverineFx console (largest version jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)