### PR TITLE
Update Cleipnir.ResilientFunctions submodule and adapt to API changes

### DIFF
--- a/Cleipnir.Tests/Flows/FlowsWithResultTests.cs
+++ b/Cleipnir.Tests/Flows/FlowsWithResultTests.cs
@@ -74,7 +74,7 @@ public class FlowsWithResultTests
         var scheduled = await flows.Schedule("someInstanceId", "someParameter");
 
         // Flow uses non-suspending delay, so it completes directly
-        var result = await scheduled.Completion(maxWait: TimeSpan.FromSeconds(5));
+        var result = await scheduled.Completion(timeout: TimeSpan.FromSeconds(5));
         result.ShouldBe(1);
     }
 

--- a/ServiceBuses/Kafka/Cleipnir.Kafka.Tests/MessageTests.cs
+++ b/ServiceBuses/Kafka/Cleipnir.Kafka.Tests/MessageTests.cs
@@ -30,7 +30,7 @@ public sealed class MessageTests
                 )
         );
 
-        await scheduled.Completion(maxWait: TimeSpan.FromSeconds(15));
+        await scheduled.Completion(timeout: TimeSpan.FromSeconds(15));
     }
 
     private class TestFlow : Flow


### PR DESCRIPTION
## Summary
- Bump `Cleipnir.ResilientFunctions` submodule from `ee98fba9` to `2721626f`, picking up upstream PRs #138–#141 (test SDK upgrade, Postman wrapper removal, dead-code cleanup, and the `maxWait` → `timeout` rename on `Scheduled.Completion`).
- Adapt two call sites for the parameter rename:
  - `Cleipnir.Tests/Flows/FlowsWithResultTests.cs`
  - `ServiceBuses/Kafka/Cleipnir.Kafka.Tests/MessageTests.cs`

## Test plan
- [x] `dotnet build Cleipnir.NET.sln` succeeds with 0 warnings, 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)