### PR TITLE
Rename RegisterFlows to RegisterFlow in IoC binding setup

### DIFF
--- a/Cleipnir.Tests.AspNet/IntegrationTest.cs
+++ b/Cleipnir.Tests.AspNet/IntegrationTest.cs
@@ -79,7 +79,7 @@ public class IntegrationTest
         bindings(builder.Services);
         builder.Services.AddFlows(c => c
             .UseStore(functionStore)
-            .RegisterFlows<TestFlow, string, string>()
+            .RegisterFlow<TestFlow, string, string>()
         );
 
         var app = builder.Build();

--- a/Cleipnir.Tests/Flows/OptionsTests.cs
+++ b/Cleipnir.Tests/Flows/OptionsTests.cs
@@ -21,7 +21,7 @@ public class OptionsTests
                 messagesDefaultMaxWaitForCompletion: TimeSpan.FromDays(1),
                 watchdogCheckFrequency: TimeSpan.FromMilliseconds(100)
             ))
-            .RegisterFlows<OptionsTestWithDefaultProvidedOptionsFlow>()
+            .RegisterFlow<OptionsTestWithDefaultProvidedOptionsFlow>()
         );
         serviceCollection.AddScoped<OptionsTestWithOverriddenOptionsFlow>();
         serviceCollection.AddTransient(sp => new Flows<OptionsTestWithOverriddenOptionsFlow>(

--- a/Cleipnir/AspNet/FlowsModule.cs
+++ b/Cleipnir/AspNet/FlowsModule.cs
@@ -61,7 +61,7 @@ public class FlowsConfigurator(IServiceCollection services)
         return this;
     }
 
-    public FlowsConfigurator RegisterFlows<TFlow>() where TFlow : Flow
+    public FlowsConfigurator RegisterFlow<TFlow>() where TFlow : Flow
     {
         var added = FlowsTypes.Add(typeof(Flows<TFlow>));
         if (!added) return this;
@@ -76,7 +76,7 @@ public class FlowsConfigurator(IServiceCollection services)
 
         return this;
     }
-    public FlowsConfigurator RegisterFlows<TFlow, TParam>() where TFlow : Flow<TParam> where TParam : notnull
+    public FlowsConfigurator RegisterFlow<TFlow, TParam>() where TFlow : Flow<TParam> where TParam : notnull
     {
         var added = FlowsTypes.Add(typeof(Flows<TFlow, TParam>));
         if (!added) return this;
@@ -91,7 +91,7 @@ public class FlowsConfigurator(IServiceCollection services)
 
         return this;
     }
-    public FlowsConfigurator RegisterFlows<TFlow, TParam, TResult>() where TFlow : Flow<TParam, TResult> where TParam : notnull
+    public FlowsConfigurator RegisterFlow<TFlow, TParam, TResult>() where TFlow : Flow<TParam, TResult> where TParam : notnull
     {
         var added = FlowsTypes.Add(typeof(Flows<TFlow, TParam, TResult>));
         if (!added) return this;

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Secondly, add the following to the setup in `Program.cs` ([source code](https://
 ```csharp
 builder.Services.AddFlows(c => c
   .UsePostgresStore(connectionString)  
-  .RegisterFlows<OrderFlow, Order>()
+  .RegisterFlow<OrderFlow, Order>()
 );
 ```
 

--- a/Samples/Cleipnir.Sample.AspNet/Program.cs
+++ b/Samples/Cleipnir.Sample.AspNet/Program.cs
@@ -28,7 +28,7 @@ internal static class Program
         builder.Services.AddFlows(c => c
             .UsePostgresStore(connectionString)
             .WithOptions(new Options(leaseLength: TimeSpan.FromSeconds(5)))
-            .RegisterFlows<OrderFlow, Order>()
+            .RegisterFlow<OrderFlow, Order>()
         );
         
         // Add services to the container.

--- a/Samples/Cleipnir.Sample.Presentation.AspNet/Program.cs
+++ b/Samples/Cleipnir.Sample.Presentation.AspNet/Program.cs
@@ -33,11 +33,11 @@ internal static class Program
         builder.Services.AddFlows(c => c
             .UsePostgresStore(connectionString)
             .WithOptions(new Options(leaseLength: TimeSpan.FromSeconds(5), messagesDefaultMaxWaitForCompletion: TimeSpan.MaxValue))
-            .RegisterFlows<OrderFlow, Order>()
-            .RegisterFlows<BatchOrderFlow, List<Order>>()
-            .RegisterFlows<SingleOrderFlow, Order, TransactionIdAndTrackAndTrace>()
-            .RegisterFlows<InvoiceFlow, CustomerNumber>()
-            .RegisterFlows<MessageDrivenOrderFlow, Order>()
+            .RegisterFlow<OrderFlow, Order>()
+            .RegisterFlow<BatchOrderFlow, List<Order>>()
+            .RegisterFlow<SingleOrderFlow, Order, TransactionIdAndTrackAndTrace>()
+            .RegisterFlow<InvoiceFlow, CustomerNumber>()
+            .RegisterFlow<MessageDrivenOrderFlow, Order>()
         );
 
         builder.Services.AddInMemoryBus();

--- a/Samples/Cleipnir.Sample.Presentation/C_NewsletterSender/Distributed/Example.cs
+++ b/Samples/Cleipnir.Sample.Presentation/C_NewsletterSender/Distributed/Example.cs
@@ -22,7 +22,7 @@ public static class Example
                     c => c
                         .UseStore(store)
                         .WithOptions(new Options(unhandledExceptionHandler: Console.WriteLine))
-                        .RegisterFlows<NewsletterParentFlow, MailAndRecipients>()
+                        .RegisterFlow<NewsletterParentFlow, MailAndRecipients>()
                 );
                 serviceCollection.AddScoped(sp => new NewsletterChildFlow(sp.GetRequiredService<Flows<NewsletterParentFlow, MailAndRecipients>>(), child));
                 serviceCollection.AddTransient(sp => new Flows<NewsletterChildFlow, NewsletterChildWork>(

--- a/Samples/Cleipnir.Sample.Presentation/C_NewsletterSender/Example.cs
+++ b/Samples/Cleipnir.Sample.Presentation/C_NewsletterSender/Example.cs
@@ -20,7 +20,7 @@ public static class Example
             c => c
                 .UseStore(store)
                 .WithOptions(new Options(unhandledExceptionHandler: Console.WriteLine))
-                .RegisterFlows<NewsletterFlow, MailAndRecipients>()
+                .RegisterFlow<NewsletterFlow, MailAndRecipients>()
         );
 
         var sp = serviceCollection.BuildServiceProvider();

--- a/ServiceBuses/MassTransit/Cleipnir.MassTransit.Console/Program.cs
+++ b/ServiceBuses/MassTransit/Cleipnir.MassTransit.Console/Program.cs
@@ -36,7 +36,7 @@ internal static class Program
             {
                 services.AddFlows(c => c
                     .UseInMemoryStore()
-                    .RegisterFlows<SimpleFlow>()
+                    .RegisterFlow<SimpleFlow>()
                 );
                 
                 services.AddMassTransit(x =>

--- a/ServiceBuses/MassTransit/Cleipnir.MassTransit.RabbitMq.Console/Program.cs
+++ b/ServiceBuses/MassTransit/Cleipnir.MassTransit.RabbitMq.Console/Program.cs
@@ -45,7 +45,7 @@ internal static class Program
                 
                 services.AddFlows(c => c
                     .UseInMemoryStore()
-                    .RegisterFlows<OrderFlow, Order>()
+                    .RegisterFlow<OrderFlow, Order>()
                 );
                 
                 services.AddMassTransit(x =>

--- a/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Console/Program.cs
+++ b/ServiceBuses/NServiceBus/Cleipnir.NServiceBus.Console/Program.cs
@@ -36,7 +36,7 @@ internal static class Program
             {
                 services.AddFlows(c => c
                         .UseInMemoryStore()
-                        .RegisterFlows<SimpleFlow>()
+                        .RegisterFlow<SimpleFlow>()
                 );
 
             }).UseNServiceBus(_ =>

--- a/ServiceBuses/Rebus/Cleipnir.Rebus.Console/Program.cs
+++ b/ServiceBuses/Rebus/Cleipnir.Rebus.Console/Program.cs
@@ -37,7 +37,7 @@ internal static class Program
             {
                 services.AddFlows(c => c
                     .UseInMemoryStore()
-                    .RegisterFlows<SimpleFlow>()
+                    .RegisterFlow<SimpleFlow>()
                 );
 
                 services.AutoRegisterHandlersFromAssembly(typeof(Program).Assembly);

--- a/ServiceBuses/Wolverine/Cleipnir.Wolverine.Console/Program.cs
+++ b/ServiceBuses/Wolverine/Cleipnir.Wolverine.Console/Program.cs
@@ -37,7 +37,7 @@ public static class Program
             {
                 services.AddFlows(c => c
                     .UseInMemoryStore()
-                    .RegisterFlows<SimpleFlow>()
+                    .RegisterFlow<SimpleFlow>()
                 );
             })
             .UseWolverine();


### PR DESCRIPTION
## Summary
- Rename the three `FlowsConfigurator.RegisterFlows<...>` overloads in `Cleipnir/AspNet/FlowsModule.cs` to `RegisterFlow` — each call registers a single flow type, so the singular form reads more naturally at call sites.
- Update all 13 call sites across samples, console apps, tests, and the README example.

## Test plan
- [x] `dotnet build Cleipnir.NET.sln` succeeds with 0 warnings, 0 errors
- [x] `grep -r RegisterFlows` returns no remaining references (`*.cs`, `*.md`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)