### PR TITLE
Remove unused GenerateFlowsAttribute

### DIFF
--- a/Cleipnir/GenerateFlowsAttribute.cs
+++ b/Cleipnir/GenerateFlowsAttribute.cs
@@ -1,4 +1,0 @@
-namespace Cleipnir.Flows;
-
-[System.AttributeUsage(System.AttributeTargets.Class)]
-public class GenerateFlowsAttribute : System.Attribute;

--- a/Samples/Cleipnir.Sample.Presentation.AspNet/Flows/Rpc/OrderFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation.AspNet/Flows/Rpc/OrderFlow.cs
@@ -6,7 +6,6 @@ using Polly.Retry;
 
 namespace Cleipnir.Flows.Sample.MicrosoftOpen.Flows.Rpc;
 
-//[GenerateFlows]
 public class OrderFlow(
     IPaymentProviderClient paymentProviderClient,
     IEmailClient emailClient,

--- a/Samples/Cleipnir.Sample.Presentation/D_LoanApplication/LoanApplicationFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/D_LoanApplication/LoanApplicationFlow.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.D_LoanApplication;
 
-[GenerateFlows]
 public class LoanApplicationFlow : Flow<LoanApplication>
 {
     public override async Task Run(LoanApplication loanApplication)

--- a/Samples/Cleipnir.Sample.Presentation/D_LoanApplication/Solution/LoanApplicationFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/D_LoanApplication/Solution/LoanApplicationFlow.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.D_LoanApplication.Solution;
 
-[GenerateFlows]
 public class LoanApplicationFlow : Flow<LoanApplication>
 {
     public override async Task Run(LoanApplication loanApplication)

--- a/Samples/Cleipnir.Sample.Presentation/E_CustomerSignup/SignupFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/E_CustomerSignup/SignupFlow.cs
@@ -1,6 +1,5 @@
 namespace Cleipnir.Flows.Sample.Presentation.E_CustomerSignup;
 
-[GenerateFlows]
 public class SignupFlow : Flow<string>
 {
     public override async Task Run(string customerEmail)

--- a/Samples/Cleipnir.Sample.Presentation/E_CustomerSignup/Solution/SignupFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/E_CustomerSignup/Solution/SignupFlow.cs
@@ -1,6 +1,5 @@
 namespace Cleipnir.Flows.Sample.Presentation.E_CustomerSignup.Solution;
 
-[GenerateFlows]
 public class SignupFlow : Flow<string>
 {
     public override async Task Run(string customerEmail)

--- a/Samples/Cleipnir.Sample.Presentation/F_SmsVerificationFlow/SmsFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/F_SmsVerificationFlow/SmsFlow.cs
@@ -11,7 +11,6 @@ public enum MostRecentAttempt
 
 public record CodeFromUser(string CustomerPhoneNumber, string Code, DateTime Timestamp);
 
-[GenerateFlows]
 public class SmsFlow : Flow<string, MostRecentAttempt>
 {
     public override async Task<MostRecentAttempt> Run(string customerPhoneNumber)

--- a/Samples/Cleipnir.Sample.Presentation/G_SupportTicket/Solution/SupportTicketFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/G_SupportTicket/Solution/SupportTicketFlow.cs
@@ -1,6 +1,5 @@
 namespace Cleipnir.Flows.Sample.Presentation.G_SupportTicket.Solution;
 
-[GenerateFlows]
 public class SupportTicketFlow : Flow<SupportTicketRequest>
 {
     public override async Task Run(SupportTicketRequest request)

--- a/Samples/Cleipnir.Sample.Presentation/G_SupportTicket/SupportTicketFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/G_SupportTicket/SupportTicketFlow.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.G_SupportTicket;
 
-[GenerateFlows]
 public class SupportTicketFlow : Flow<SupportTicketRequest>
 {
     public override async Task Run(SupportTicketRequest request)

--- a/Samples/Cleipnir.Sample.Presentation/J_OrderSupervisor/OrderSupervisorFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/J_OrderSupervisor/OrderSupervisorFlow.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.J_OrderSupervisor;
 
-[GenerateFlows]
 public class OrderSupervisorFlow : Flow<Order>
 {
     public override async Task Run(Order order)

--- a/Samples/Cleipnir.Sample.Presentation/OutBoxPattern/OutboxFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/OutBoxPattern/OutboxFlow.cs
@@ -2,7 +2,6 @@ using Cleipnir.Flows.Sample.Presentation.A_OrderFlowRpc;
 
 namespace Cleipnir.Flows.Sample.Presentation.OutBoxPattern;
 
-[GenerateFlows]
 public class OutboxFlow(IBus bus) : Flow<Order>
 {
     public override async Task Run(Order order)

--- a/Samples/Cleipnir.Sample.Presentation/OutBoxPattern/Solution/OutboxFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/OutBoxPattern/Solution/OutboxFlow.cs
@@ -2,7 +2,6 @@ using Cleipnir.Flows.Sample.Presentation.A_OrderFlowRpc;
 
 namespace Cleipnir.Flows.Sample.Presentation.OutBoxPattern.Solution;
 
-[GenerateFlows]
 public class OutboxFlow(IBus bus) : Flow<Order>
 {
     public override async Task Run(Order order)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow0.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow0.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.Solutions.A_OrderFlowRpc;
 
-[GenerateFlows]
 public class OrderFlow0 : Flow<Order>
 {
     private readonly IPaymentProviderClient _paymentProviderClient;

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow1.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow1.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cleipnir.Flows.Sample.Presentation.Solutions.A_OrderFlowRpc;
 
-[GenerateFlows]
 public class OrderFlow1 : Flow<Order>
 {
     private readonly IPaymentProviderClient _paymentProviderClient;

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow2.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/A_OrderFlowRpc/OrderFlow2.cs
@@ -2,7 +2,6 @@
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.A_OrderFlowRpc;
 
-[GenerateFlows]
 public class OrderFlow2 : Flow<Order>
 {
     private readonly IPaymentProviderClient _paymentProviderClient;

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/B_OrderFlowMessaging/OrderFlow.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/B_OrderFlowMessaging/OrderFlow.cs
@@ -2,7 +2,6 @@
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.B_OrderFlowMessaging;
 
-[GenerateFlows]
 public class OrderFlow(Bus bus) : Flow<Order>
 {
     public override async Task Run(Order order)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow0.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow0.cs
@@ -4,7 +4,6 @@ using MimeKit.Text;
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.C_NewsletterSender;
 
-[GenerateFlows]
 public class NewsletterFlow0 : Flow<MailAndRecipients>
 {
     public override async Task Run(MailAndRecipients mailAndRecipients)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow1.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow1.cs
@@ -4,7 +4,6 @@ using MimeKit.Text;
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.C_NewsletterSender;
 
-[GenerateFlows]
 public class NewsletterFlow1 : Flow<MailAndRecipients>
 {
     public override async Task Run(MailAndRecipients mailAndRecipients)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow_Parallelized.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow_Parallelized.cs
@@ -4,7 +4,6 @@ using MimeKit.Text;
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.C_NewsletterSender;
 
-[GenerateFlows]
 public class NewsletterFlow_Parallelized : Flow<MailAndRecipients>
 {
     public override async Task Run(MailAndRecipients mailAndRecipients)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow_SpaceOptimized.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/C_NewsletterSender/NewsletterFlow_SpaceOptimized.cs
@@ -4,7 +4,6 @@ using MimeKit.Text;
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.C_NewsletterSender;
 
-[GenerateFlows]
 public class NewsletterFlow_SpaceOptimized : Flow<MailAndRecipients>
 {
     public override async Task Run(MailAndRecipients mailAndRecipients)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow0.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow0.cs
@@ -2,7 +2,6 @@
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.D_LoanApplication;
 
-[GenerateFlows]
 public class LoanApplicationFlow0 : Flow<LoanApplication>
 {
     public override async Task Run(LoanApplication loanApplication)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow1.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow1.cs
@@ -2,7 +2,6 @@
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.D_LoanApplication;
 
-[GenerateFlows]
 public class LoanApplicationFlow1 : Flow<LoanApplication>
 {
     public override async Task Run(LoanApplication loanApplication)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow2.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/D_LoanApplication/LoanApplicationFlow2.cs
@@ -2,7 +2,6 @@
 
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.D_LoanApplication;
 
-[GenerateFlows]
 public class LoanApplicationFlow2 : Flow<LoanApplication>
 {
     public override async Task Run(LoanApplication loanApplication)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/E_CustomerSignup/SignupFlow0.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/E_CustomerSignup/SignupFlow0.cs
@@ -1,6 +1,5 @@
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.E_CustomerSignup;
 
-[GenerateFlows]
 public class SignupFlow0 : Flow<string>
 {
     public override async Task Run(string customerEmail)

--- a/Samples/Cleipnir.Sample.Presentation/Solutions/E_CustomerSignup/SignupFlow1.cs
+++ b/Samples/Cleipnir.Sample.Presentation/Solutions/E_CustomerSignup/SignupFlow1.cs
@@ -1,6 +1,5 @@
 namespace Cleipnir.Flows.Sample.Presentation.Solutions.E_CustomerSignup;
 
-[GenerateFlows]
 public class SignupFlow1 : Flow<string>
 {
     public override async Task Run(string customerEmail)


### PR DESCRIPTION
## Summary
- Delete `Cleipnir/GenerateFlowsAttribute.cs` — the attribute had no generator or runtime behavior backing it
- Strip the `[GenerateFlows]` marker from all 24 sample files that referenced it (including the commented-out usage in `Samples/Cleipnir.Sample.Presentation.AspNet/Flows/Rpc/OrderFlow.cs`)

## Test plan
- [ ] `dotnet build Cleipnir.NET.sln` — note: there are 2 pre-existing build errors on `main` related to a `Completion(timeout: ...)` overload in `Cleipnir.Kafka.Tests` and `Cleipnir.Tests`; both reproduce without this PR and are unrelated to the attribute removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)