### PR TITLE
Adapt to latest ResilientFunctions API changes

### DIFF
--- a/Cleipnir.Tests/Flows/FunctionRegistrationTests.cs
+++ b/Cleipnir.Tests/Flows/FunctionRegistrationTests.cs
@@ -35,7 +35,7 @@ public class FunctionRegistrationTests
             param: "SomeParam",
             new InitialState(
                 [new MessageAndIdempotencyKey(new StringMessage("InitialMessageValue"))],
-                [new InitialEffect(0, "InitialEffectValue")]
+                [new InitialEffect(0.ToEffectId(), "InitialEffectValue")]
             )
         );
 

--- a/Cleipnir.Tests/Flows/ParamlessFlowsTests.cs
+++ b/Cleipnir.Tests/Flows/ParamlessFlowsTests.cs
@@ -158,7 +158,7 @@ public class ParamlessFlowsTests
             "SomeInstanceId",
             new InitialState(
                 [new MessageAndIdempotencyKey(new StringMessage("InitialMessageValue"))],
-                [new InitialEffect(0, "InitialEffectValue")]
+                [new InitialEffect(0.ToEffectId(), "InitialEffectValue")]
             )
         );
 

--- a/Cleipnir.Tests/Flows/UnitFlowsTests.cs
+++ b/Cleipnir.Tests/Flows/UnitFlowsTests.cs
@@ -265,7 +265,7 @@ public class UnitFlowsTests
             param: "SomeParam",
             new InitialState(
                 [new MessageAndIdempotencyKey(new StringMessage("InitialMessageValue"))],
-                [new InitialEffect(0, "InitialEffectValue")]
+                [new InitialEffect(0.ToEffectId(), "InitialEffectValue")]
             )
         );
 

--- a/Cleipnir/FlowsContainer.cs
+++ b/Cleipnir/FlowsContainer.cs
@@ -27,16 +27,17 @@ public class FlowsContainer : IDisposable
             var logger = serviceProvider.GetRequiredService<ILogger>();
             options = new Options(
                     unhandledExceptionHandler: ex => logger.LogError(ex, "Unhandled exception in Cleipnir"),
-                    options.RetentionPeriod,
-                    options.RetentionCleanUpFrequency,
-                    options.LeaseLength,
-                    options.EnableWatchdogs,
-                    options.WatchdogCheckFrequency,
-                    options.MessagesPullFrequency,
-                    options.MessagesDefaultMaxWaitForCompletion,
-                    options.DelayStartup,
-                    options.MaxParallelRetryInvocations,
-                    options.Serializer
+                    retentionPeriod: options.RetentionPeriod,
+                    retentionCleanUpFrequency: options.RetentionCleanUpFrequency,
+                    enableWatchdogs: options.EnableWatchdogs,
+                    watchdogCheckFrequency: options.WatchdogCheckFrequency,
+                    messagesPullFrequency: options.MessagesPullFrequency,
+                    messagesDefaultMaxWaitForCompletion: options.MessagesDefaultMaxWaitForCompletion,
+                    delayStartup: options.DelayStartup,
+                    maxParallelRetryInvocations: options.MaxParallelRetryInvocations,
+                    serializer: options.Serializer,
+                    utcNow: options.UtcNow,
+                    replicaHeartbeatFrequency: options.ReplicaHeartbeatFrequency
                 );
         }
 

--- a/Cleipnir/Options.cs
+++ b/Cleipnir/Options.cs
@@ -13,7 +13,6 @@ public class Options
     internal Action<FrameworkException>? UnhandledExceptionHandler { get; }
     internal TimeSpan? RetentionPeriod { get; }
     internal TimeSpan? RetentionCleanUpFrequency { get; }
-    internal TimeSpan? LeaseLength { get; }
     internal bool? EnableWatchdogs { get; }
     internal TimeSpan? WatchdogCheckFrequency { get; }
     internal TimeSpan? DelayStartup { get; }
@@ -22,6 +21,7 @@ public class Options
     internal TimeSpan? MessagesDefaultMaxWaitForCompletion { get; }
     internal ISerializer? Serializer { get; }
     internal UtcNow? UtcNow { get; }
+    internal TimeSpan? ReplicaHeartbeatFrequency { get; }
 
     /// <summary>
     /// Configuration options for Cleipnir
@@ -29,7 +29,6 @@ public class Options
     /// <param name="unhandledExceptionHandler">Callback handler for unhandled flow exceptions</param>
     /// <param name="retentionPeriod">Period to keep completed flows before deletion. Default infinite.</param>
     /// <param name="retentionCleanUpFrequency">Retention clean-up check frequency. Default 1 hour when retention period is not infinite.</param>
-    /// <param name="leaseLength">Flow lease-length. Leases are automatically renewed. Default 60 seconds.</param>
     /// <param name="enableWatchdogs">Enable background crashed, interrupted and postponed flow scheduling. Default true.</param>
     /// <param name="watchdogCheckFrequency">Check frequency for eligible crashed, interrupted and postponed flows. Default 1 second.</param>
     /// <param name="messagesPullFrequency">Pull frequency for active/max-waiting messages. Default: 250ms</param>
@@ -38,11 +37,11 @@ public class Options
     /// <param name="maxParallelRetryInvocations">Limit the number of watchdog started invocations. Default: 100.</param>
     /// <param name="serializer">Specify custom serializer. Default built-in json-serializer.</param>
     /// <param name="utcNow">Provide custom delegate for providing current utc datetime. Default: () => DateTime.UtcNow</param>
+    /// <param name="replicaHeartbeatFrequency">Heartbeat frequency for replica liveness detection. Default 1 second.</param>
     public Options(
         Action<FrameworkException>? unhandledExceptionHandler = null,
         TimeSpan? retentionPeriod = null,
         TimeSpan? retentionCleanUpFrequency = null,
-        TimeSpan? leaseLength = null,
         bool? enableWatchdogs = null,
         TimeSpan? watchdogCheckFrequency = null,
         TimeSpan? messagesPullFrequency = null,
@@ -50,12 +49,12 @@ public class Options
         TimeSpan? delayStartup = null,
         int? maxParallelRetryInvocations = null,
         ISerializer? serializer = null,
-        UtcNow? utcNow = null
+        UtcNow? utcNow = null,
+        TimeSpan? replicaHeartbeatFrequency = null
     )
     {
         UnhandledExceptionHandler = unhandledExceptionHandler;
         WatchdogCheckFrequency = watchdogCheckFrequency;
-        LeaseLength = leaseLength;
         RetentionPeriod = retentionPeriod;
         RetentionCleanUpFrequency = retentionCleanUpFrequency;
         EnableWatchdogs = enableWatchdogs;
@@ -65,6 +64,7 @@ public class Options
         MaxParallelRetryInvocations = maxParallelRetryInvocations;
         Serializer = serializer;
         UtcNow = utcNow;
+        ReplicaHeartbeatFrequency = replicaHeartbeatFrequency;
     }
 
     public Options Merge(Options options)
@@ -73,30 +73,31 @@ public class Options
             UnhandledExceptionHandler ?? options.UnhandledExceptionHandler,
             RetentionPeriod ?? options.RetentionPeriod,
             RetentionCleanUpFrequency ?? options.RetentionCleanUpFrequency,
-            LeaseLength ?? options.LeaseLength,
             EnableWatchdogs ?? options.EnableWatchdogs,
             WatchdogCheckFrequency ?? options.WatchdogCheckFrequency,
             MessagesPullFrequency ?? options.MessagesPullFrequency,
             MessagesDefaultMaxWaitForCompletion ?? options.MessagesDefaultMaxWaitForCompletion,
             DelayStartup ?? options.DelayStartup,
             MaxParallelRetryInvocations ?? options.MaxParallelRetryInvocations,
-            Serializer ?? options.Serializer
+            Serializer ?? options.Serializer,
+            UtcNow ?? options.UtcNow,
+            ReplicaHeartbeatFrequency ?? options.ReplicaHeartbeatFrequency
         );
     }
 
     internal Settings MapToSettings()
         => new(
-            UnhandledExceptionHandler,
-            RetentionPeriod,
-            RetentionCleanUpFrequency,
-            LeaseLength,
-            EnableWatchdogs,
-            WatchdogCheckFrequency,
-            MessagesPullFrequency,
-            MessagesDefaultMaxWaitForCompletion,
-            DelayStartup,
-            MaxParallelRetryInvocations,
-            Serializer,
-            UtcNow
+            unhandledExceptionHandler: UnhandledExceptionHandler,
+            retentionPeriod: RetentionPeriod,
+            retentionCleanUpFrequency: RetentionCleanUpFrequency,
+            enableWatchdogs: EnableWatchdogs,
+            watchdogCheckFrequency: WatchdogCheckFrequency,
+            messagesPullFrequency: MessagesPullFrequency,
+            messagesDefaultMaxWaitForCompletion: MessagesDefaultMaxWaitForCompletion,
+            delayStartup: DelayStartup,
+            maxParallelRetryInvocations: MaxParallelRetryInvocations,
+            serializer: Serializer,
+            utcNow: UtcNow,
+            replicaHeartbeatFrequency: ReplicaHeartbeatFrequency
         );
 }

--- a/Samples/Cleipnir.Sample.AspNet/Program.cs
+++ b/Samples/Cleipnir.Sample.AspNet/Program.cs
@@ -27,7 +27,7 @@ internal static class Program
         await DatabaseHelper.CreateDatabaseIfNotExists(connectionString); //use to create db initially or clean existing state in database
         builder.Services.AddFlows(c => c
             .UsePostgresStore(connectionString)
-            .WithOptions(new Options(leaseLength: TimeSpan.FromSeconds(5)))
+            .WithOptions(new Options(replicaHeartbeatFrequency: TimeSpan.FromSeconds(5)))
             .RegisterFlow<OrderFlow, Order>()
         );
         

--- a/Samples/Cleipnir.Sample.Presentation.AspNet/Program.cs
+++ b/Samples/Cleipnir.Sample.Presentation.AspNet/Program.cs
@@ -32,7 +32,7 @@ internal static class Program
         //await DatabaseHelper.RecreateDatabase(connectionString);
         builder.Services.AddFlows(c => c
             .UsePostgresStore(connectionString)
-            .WithOptions(new Options(leaseLength: TimeSpan.FromSeconds(5), messagesDefaultMaxWaitForCompletion: TimeSpan.MaxValue))
+            .WithOptions(new Options(replicaHeartbeatFrequency: TimeSpan.FromSeconds(5), messagesDefaultMaxWaitForCompletion: TimeSpan.MaxValue))
             .RegisterFlow<OrderFlow, Order>()
             .RegisterFlow<BatchOrderFlow, List<Order>>()
             .RegisterFlow<SingleOrderFlow, Order, TransactionIdAndTrackAndTrace>()


### PR DESCRIPTION
## Summary
Updates the consuming code to compile and run against the latest `Cleipnir.ResilientFunctions` submodule, which changed two APIs:

- `Settings` constructor **dropped `leaseLength`** and **added `replicaHeartbeatFrequency`** (also shifting positional argument order).
- `EffectId` **no longer converts implicitly from `int`**.

## Changes
- **`Cleipnir/Options.cs`** — replaced `LeaseLength` with `ReplicaHeartbeatFrequency` (property, constructor parameter, XML doc), wired it through `Merge` and `MapToSettings`, and switched `MapToSettings` to named arguments. Also fixed a latent bug where `Merge` silently dropped `UtcNow`.
- **`Cleipnir/FlowsContainer.cs`** — the logger-injection path rebuilt `Options` positionally and dropped several settings; switched to named arguments so no options are lost.
- **Tests** (`FunctionRegistrationTests`, `ParamlessFlowsTests`, `UnitFlowsTests`) — construct `InitialEffect` with an `EffectId` via `0.ToEffectId()`.
- **Samples** (`Cleipnir.Sample.AspNet`, `Cleipnir.Sample.Presentation.AspNet`) — use `replicaHeartbeatFrequency` instead of `leaseLength`.

## Testing
- `dotnet build Cleipnir.NET.sln` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)